### PR TITLE
fix: remove hardcoded paths from skill files for portability

### DIFF
--- a/.opencode/skills/verify-readiness/SKILL.md
+++ b/.opencode/skills/verify-readiness/SKILL.md
@@ -103,7 +103,7 @@ bun run scripts/test-browser.ts --url http://localhost:5001 --user admin --pass 
 
 ```bash
 lsof -ti:5001
-cd /Users/engineer/workspace/opencode-manager
+cd /path/to/opencode-manager
 AUTH_USERNAME=admin AUTH_PASSWORD=PASSWORD PORT=5001 bun backend/src/index.ts
 ```
 

--- a/skills/verify-readiness/SKILL.md
+++ b/skills/verify-readiness/SKILL.md
@@ -103,7 +103,7 @@ bun run scripts/test-browser.ts --url http://localhost:5001 --user admin --pass 
 
 ```bash
 lsof -ti:5001
-cd /Users/engineer/workspace/opencode-manager
+cd /path/to/opencode-manager
 AUTH_USERNAME=admin AUTH_PASSWORD=PASSWORD PORT=5001 bun backend/src/index.ts
 ```
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `/Users/engineer/workspace/opencode-manager` path from skill files
- Replace with generic `/path/to/opencode-manager` placeholder
- Prepares codebase for contribution to upstream

## Changes
- `skills/verify-readiness/SKILL.md`: Updated path reference
- `.opencode/skills/verify-readiness/SKILL.md`: Updated path reference

## Testing
- All 161 unit tests pass