### PR TITLE
fix: prevent 27GB log spam from GlobalSSE reconnection loop

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,7 @@ import { logger } from './utils/logger'
 import { chatterboxServerManager } from './services/chatterbox'
 import { startGlobalSSEListener, stopGlobalSSEListener } from './services/global-sse'
 import { autoPruneOnStartup } from './services/session-prune'
+import { startLogMaintenance } from './utils/log-maintenance'
 import { 
   getWorkspacePath, 
   getReposPath, 
@@ -274,6 +275,8 @@ async function ensureDefaultAgentsMdExists(): Promise<void> {
 }
 
 try {
+  startLogMaintenance()
+
   await ensureDirectoryExists(getWorkspacePath())
   await ensureDirectoryExists(getReposPath())
   await ensureDirectoryExists(getConfigPath())

--- a/backend/src/services/global-sse.ts
+++ b/backend/src/services/global-sse.ts
@@ -5,27 +5,76 @@ import { opencodeServerManager } from './opencode-single-server'
 import { sendSessionCompleteNotification, sendPermissionRequestNotification } from './push'
 import { logger } from '../utils/logger'
 
+// GlobalSSE connects to OpenCode's /event endpoint for push notifications.
+// IMPORTANT: Only connects to directories that have active OpenCode sessions.
+// This prevents log spam from failed connections to directories OpenCode doesn't serve.
+
 interface SSEEvent {
   type: string
   properties: Record<string, unknown>
 }
 
-let globalEventSources: Map<string, EventSource> = new Map()
+interface ConnectionState {
+  eventSource: EventSource
+  retryCount: number
+  lastErrorLogTime: number
+  consecutiveFailures: number
+}
+
+// Retry delays: 10s, 20s, 40s, 80s, 160s, then cap at 5 minutes
+const MIN_RETRY_DELAY = 10000
+const MAX_RETRY_DELAY = 300000
+// Only log errors once every 5 minutes per directory to prevent log spam
+const ERROR_LOG_INTERVAL = 300000
+const SYNC_INTERVAL = 30000
+// Stop retrying after 3 consecutive failures (will retry on next sync cycle)
+const MAX_CONSECUTIVE_FAILURES = 3
+
+let globalEventSources: Map<string, ConnectionState> = new Map()
+let failedDirectories: Set<string> = new Set()
 let database: Database | null = null
 let isRunning = false
+let syncInterval: NodeJS.Timeout | null = null
+
+// Query OpenCode for directories that have active sessions
+// Only these directories can receive SSE events
+async function getActiveDirectoriesFromOpenCode(): Promise<Set<string>> {
+  const directories = new Set<string>()
+  
+  try {
+    const port = opencodeServerManager.getPort()
+    const response = await fetch(`http://127.0.0.1:${port}/session`, {
+      signal: AbortSignal.timeout(5000)
+    })
+    
+    if (response.ok) {
+      const sessions = await response.json() as Array<{ directory?: string }>
+      for (const session of sessions) {
+        if (session.directory) {
+          directories.add(session.directory)
+        }
+      }
+    }
+  } catch {
+    // OpenCode not available - return empty set, will retry on next sync
+  }
+  
+  return directories
+}
 
 async function getSessionTitle(directory: string, sessionId: string): Promise<string | undefined> {
   try {
     const port = opencodeServerManager.getPort()
     const response = await fetch(
-      `http://127.0.0.1:${port}/session/${sessionId}?directory=${encodeURIComponent(directory)}`
+      `http://127.0.0.1:${port}/session/${sessionId}?directory=${encodeURIComponent(directory)}`,
+      { signal: AbortSignal.timeout(5000) }
     )
     if (response.ok) {
       const session = await response.json()
       return session.title
     }
-  } catch (err) {
-    logger.warn(`Failed to fetch session title for ${sessionId}:`, err)
+  } catch {
+    // Ignore errors for session title fetch - not critical
   }
   return undefined
 }
@@ -66,33 +115,63 @@ function handleSSEMessage(directory: string, event: SSEEvent): void {
   }
 }
 
-function connectToRepo(directory: string): void {
-  if (globalEventSources.has(directory)) {
+function connectToDirectory(directory: string, retryCount: number = 0): void {
+  if (globalEventSources.has(directory) || failedDirectories.has(directory)) {
     return
   }
 
   const port = opencodeServerManager.getPort()
   const url = `http://127.0.0.1:${port}/event?directory=${encodeURIComponent(directory)}`
 
-  logger.info(`[GlobalSSE] Connecting to ${directory}`)
+  if (retryCount === 0) {
+    logger.info(`[GlobalSSE] Connecting to ${directory}`)
+  }
 
   const es = new EventSource(url)
-  globalEventSources.set(directory, es)
+  const state: ConnectionState = {
+    eventSource: es,
+    retryCount,
+    lastErrorLogTime: 0,
+    consecutiveFailures: 0
+  }
+  globalEventSources.set(directory, state)
 
   es.onopen = () => {
     logger.info(`[GlobalSSE] Connected to ${directory}`)
+    state.retryCount = 0
+    state.consecutiveFailures = 0
+    failedDirectories.delete(directory)
   }
 
-  es.onerror = (err) => {
-    logger.warn(`[GlobalSSE] Error for ${directory}:`, err)
+  es.onerror = () => {
+    state.consecutiveFailures++
+    
+    // Throttle error logging to prevent log spam
+    const now = Date.now()
+    if (now - state.lastErrorLogTime > ERROR_LOG_INTERVAL) {
+      logger.warn(`[GlobalSSE] Connection failed for ${directory} (attempt ${state.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES})`)
+      state.lastErrorLogTime = now
+    }
+    
     globalEventSources.delete(directory)
+    es.close()
 
+    // Give up after too many consecutive failures
+    if (state.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      logger.info(`[GlobalSSE] Giving up on ${directory} after ${MAX_CONSECUTIVE_FAILURES} failures (will retry on next sync)`)
+      failedDirectories.add(directory)
+      return
+    }
+
+    // Exponential backoff retry
     if (isRunning) {
+      const delay = Math.min(MIN_RETRY_DELAY * Math.pow(2, state.retryCount), MAX_RETRY_DELAY)
+      
       setTimeout(() => {
-        if (isRunning && !globalEventSources.has(directory)) {
-          connectToRepo(directory)
+        if (isRunning && !globalEventSources.has(directory) && !failedDirectories.has(directory)) {
+          connectToDirectory(directory, state.retryCount + 1)
         }
-      }, 5000)
+      }, delay)
     }
   }
 
@@ -106,30 +185,40 @@ function connectToRepo(directory: string): void {
   }
 }
 
-function disconnectFromRepo(directory: string): void {
-  const es = globalEventSources.get(directory)
-  if (es) {
-    es.close()
+function disconnectFromDirectory(directory: string): void {
+  const state = globalEventSources.get(directory)
+  if (state) {
+    state.eventSource.close()
     globalEventSources.delete(directory)
-    logger.info(`[GlobalSSE] Disconnected from ${directory}`)
+    logger.debug(`[GlobalSSE] Disconnected from ${directory}`)
   }
 }
 
-function syncRepoConnections(): void {
-  if (!database) return
+// Sync connections to only directories that OpenCode knows about
+async function syncConnections(): Promise<void> {
+  if (!database || !isRunning) return
 
-  const repos = db.listRepos(database)
-  const currentDirs = new Set(repos.map((r) => r.fullPath))
+  const activeDirectories = await getActiveDirectoriesFromOpenCode()
+  
+  // If OpenCode isn't running or has no sessions, don't try to connect
+  if (activeDirectories.size === 0) {
+    return
+  }
 
+  // Reset failed directories on each sync to allow retry
+  failedDirectories.clear()
+
+  // Disconnect from directories that are no longer active
   for (const [dir] of globalEventSources) {
-    if (!currentDirs.has(dir)) {
-      disconnectFromRepo(dir)
+    if (!activeDirectories.has(dir)) {
+      disconnectFromDirectory(dir)
     }
   }
 
-  for (const repo of repos) {
-    if (!globalEventSources.has(repo.fullPath)) {
-      connectToRepo(repo.fullPath)
+  // Connect to new active directories
+  for (const dir of activeDirectories) {
+    if (!globalEventSources.has(dir)) {
+      connectToDirectory(dir)
     }
   }
 }
@@ -140,23 +229,31 @@ export function startGlobalSSEListener(db: Database): void {
   database = db
   isRunning = true
 
-  logger.info('[GlobalSSE] Starting global SSE listener')
+  logger.info('[GlobalSSE] Starting global SSE listener (connects only to active OpenCode directories)')
 
-  syncRepoConnections()
+  syncConnections()
 
-  setInterval(() => {
+  syncInterval = setInterval(() => {
     if (isRunning) {
-      syncRepoConnections()
+      syncConnections()
     }
-  }, 30000)
+  }, SYNC_INTERVAL)
 }
 
 export function stopGlobalSSEListener(): void {
   isRunning = false
 
-  for (const [dir] of globalEventSources) {
-    disconnectFromRepo(dir)
+  if (syncInterval) {
+    clearInterval(syncInterval)
+    syncInterval = null
   }
+
+  for (const [dir] of globalEventSources) {
+    disconnectFromDirectory(dir)
+  }
+
+  globalEventSources.clear()
+  failedDirectories.clear()
 
   logger.info('[GlobalSSE] Stopped global SSE listener')
 }

--- a/backend/src/utils/log-maintenance.ts
+++ b/backend/src/utils/log-maintenance.ts
@@ -1,0 +1,68 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { logger } from './logger'
+
+const CONFIG_DIR = path.join(os.homedir(), '.local', 'run', 'opencode-manager')
+const MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024 // 10MB per log file
+const MAX_LOG_BACKUPS = 2
+const CHECK_INTERVAL_MS = 5 * 60 * 1000 // Check every 5 minutes
+
+const LOG_FILES = ['stdout.log', 'stderr.log', 'cloudflared.log']
+
+let maintenanceInterval: NodeJS.Timeout | null = null
+
+function truncateLogFile(logPath: string): void {
+  try {
+    if (!fs.existsSync(logPath)) return
+
+    const stats = fs.statSync(logPath)
+    if (stats.size < MAX_LOG_SIZE_BYTES) return
+
+    const sizeMB = (stats.size / (1024 * 1024)).toFixed(1)
+    logger.info(`Rotating oversized log (${sizeMB}MB): ${path.basename(logPath)}`)
+
+    const oldestBackup = `${logPath}.${MAX_LOG_BACKUPS}`
+    if (fs.existsSync(oldestBackup)) {
+      fs.unlinkSync(oldestBackup)
+    }
+
+    for (let i = MAX_LOG_BACKUPS - 1; i >= 1; i--) {
+      const current = `${logPath}.${i}`
+      const next = `${logPath}.${i + 1}`
+      if (fs.existsSync(current)) {
+        fs.renameSync(current, next)
+      }
+    }
+
+    fs.renameSync(logPath, `${logPath}.1`)
+    fs.writeFileSync(logPath, '', { flag: 'w' })
+
+  } catch (err) {
+    logger.warn(`Failed to rotate log file ${logPath}:`, err)
+  }
+}
+
+function runLogMaintenance(): void {
+  for (const logFile of LOG_FILES) {
+    const logPath = path.join(CONFIG_DIR, logFile)
+    truncateLogFile(logPath)
+  }
+}
+
+export function startLogMaintenance(): void {
+  if (maintenanceInterval) return
+
+  runLogMaintenance()
+
+  maintenanceInterval = setInterval(runLogMaintenance, CHECK_INTERVAL_MS)
+  logger.info('Log maintenance started (checks every 5 minutes)')
+}
+
+export function stopLogMaintenance(): void {
+  if (maintenanceInterval) {
+    clearInterval(maintenanceInterval)
+    maintenanceInterval = null
+    logger.info('Log maintenance stopped')
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #31 - Background service consuming 27GB disk space due to log spam from GlobalSSE reconnection loop.

## Problem

The GlobalSSE service generated **87+ million error messages** (27GB logs) because:

1. It tried to connect to ALL registered repos via SSE
2. OpenCode only serves directories with active sessions
3. Failed connections logged full error objects every 5 seconds

## Solution

### 1. Smart SSE Connection Management (`global-sse.ts`)

**Before:** Connected to all registered repos regardless of whether OpenCode serves them.

**After:** Only connects to directories that have active OpenCode sessions by querying `/session` endpoint first.

```typescript
// Query OpenCode for directories that have active sessions
async function getActiveDirectoriesFromOpenCode(): Promise<Set<string>> {
  const response = await fetch(`http://127.0.0.1:${port}/session`)
  const sessions = await response.json()
  // Only return directories with sessions - these are the only ones
  // that can receive SSE events from OpenCode
  return new Set(sessions.map(s => s.directory).filter(Boolean))
}
```

### 2. Exponential Backoff & Throttling

- Retry delays: 10s → 20s → 40s → 80s → 160s → 5min max
- Stop retrying after 3 consecutive failures (retry on next 30s sync)
- Error logging throttled to once per 5 minutes per directory

### 3. Runtime Log Maintenance (`log-maintenance.ts`)

New utility that runs every 5 minutes to rotate oversized logs:
- Max 10MB per log file
- Keep 2 backup files
- Handles stdout.log, stderr.log, cloudflared.log

## Files Changed

| File | Changes |
|------|---------|
| `backend/src/services/global-sse.ts` | Rewritten with smart connection logic, backoff, throttling |
| `backend/src/utils/log-maintenance.ts` | **New** - Runtime log rotation utility |
| `backend/src/index.ts` | Start log maintenance on boot |

## Testing

- [ ] Build passes
- [ ] Manual verification: logs don't grow unbounded
- [ ] Service reconnects properly when OpenCode has sessions