### PR TITLE
feat: add install-local script for development workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "docker:logs": "docker-compose logs -f",
     "docker:restart": "docker-compose restart",
     "install:opencode-attach": "bun scripts/install-opencode-attach.ts",
-    "uninstall:opencode-attach": "bun scripts/install-opencode-attach.ts uninstall"
+    "uninstall:opencode-attach": "bun scripts/install-opencode-attach.ts uninstall",
+    "install-local": "bash scripts/reinstall-local.sh"
   },
   "devDependencies": {
     "concurrently": "^9.1.0",

--- a/scripts/reinstall-local.sh
+++ b/scripts/reinstall-local.sh
@@ -39,6 +39,9 @@ echo "Installing from $TARBALL..."
 bun install -g "$TARBALL"
 rm -f "$TARBALL"
 
+# Trust postinstall to extract dist tarballs (bun blocks by default)
+cd ~/.bun/install/global && bun pm trust opencode-manager 2>/dev/null || true
+
 echo "[6/6] Installing and starting service..."
 opencode-manager install-service
 


### PR DESCRIPTION
## Summary

Adds the `install-local` script that was missing from main branch (existed on unmerged feature branch).

### Changes

1. **Added `pnpm install-local` script** in `package.json`
   - Calls `bash scripts/reinstall-local.sh` which properly builds, packages, and installs globally

2. **Fixed `reinstall-local.sh`** to handle bun's postinstall blocking
   - Added `bun pm trust opencode-manager` after install to ensure postinstall runs
   - Without this, `backend/dist` and `frontend/dist` aren't extracted from tarballs

### Why

The `reinstall-local.sh` script already existed and handles the complex workflow of:
- Stopping existing service
- Removing global installation
- Building backend and frontend
- Creating tarballs with dist directories
- Using `npm pack` to create proper package (avoids bun workspace issues)
- Installing globally from tarball
- Trusting postinstall to extract dist tarballs
- Installing and starting service

### Testing

```bash
# Works correctly now
pnpm install-local

# Service starts and is healthy
curl -s http://localhost:5001/api/health | jq '.status'
# Returns: "healthy"
```

Closes the gap from unmerged `feature/session-prune-and-tunnel-logs` branch.