### PR TITLE
fix: restore package.json scripts and metadata lost in upstream merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,54 @@
 {
   "name": "opencode-manager",
   "version": "0.8.25",
-  "private": false,
+  "description": "Web UI for managing OpenCode AI coding assistant sessions",
   "type": "module",
   "packageManager": "pnpm@10.28.1",
+  "bin": {
+    "opencode-manager": "./bin/cli.ts"
+  },
+  "files": [
+    "bin/",
+    "backend/",
+    "frontend/",
+    "shared/src/",
+    "scripts/whisper-server.py",
+    "scripts/chatterbox-server.py",
+    "scripts/coqui-server.py",
+    "backend-dist.tar.gz",
+    "frontend-dist.tar.gz"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dzianisv/opencode-manager.git"
+  },
+  "keywords": [
+    "opencode",
+    "ai",
+    "coding",
+    "assistant",
+    "web-ui",
+    "claude"
+  ],
+  "author": "Anthropic",
+  "license": "MIT",
   "scripts": {
     "postinstall": "if [ ! -d backend/dist ]; then tar -xzf backend-dist.tar.gz 2>/dev/null || true; fi && if [ ! -d frontend/dist ]; then tar -xzf frontend-dist.tar.gz 2>/dev/null || true; fi",
     "predev": "bash scripts/setup-dev.sh",
     "dev": "concurrently \"pnpm:dev:backend\" \"pnpm:dev:frontend\"",
     "dev:backend": "bun --watch backend/src/index.ts",
     "dev:frontend": "pnpm --filter frontend dev",
+    "start": "bun scripts/start-native.ts --tunnel",
+    "start:client": "bun scripts/start-native.ts --client --tunnel",
+    "start:no-tunnel": "bun scripts/start-native.ts",
+    "tunnel:start": "bun scripts/tunnel.ts start",
+    "tunnel:stop": "bun scripts/tunnel.ts stop",
+    "tunnel:status": "bun scripts/tunnel.ts status",
+    "cleanup": "bun scripts/cleanup.ts",
     "build": "pnpm run build:backend && pnpm run build:frontend",
     "build:backend": "pnpm --filter backend build",
     "build:frontend": "pnpm --filter frontend build",
+    "prepublishOnly": "pnpm run build",
     "typecheck": "pnpm run typecheck:frontend && pnpm run typecheck:backend",
     "typecheck:frontend": "pnpm --filter frontend typecheck",
     "typecheck:backend": "pnpm --filter backend typecheck",
@@ -27,7 +63,10 @@
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down -v",
     "docker:logs": "docker-compose logs -f",
-    "docker:restart": "docker-compose restart"
+    "docker:restart": "docker-compose restart",
+    "install:opencode-attach": "bun scripts/install-opencode-attach.ts",
+    "uninstall:opencode-attach": "bun scripts/install-opencode-attach.ts uninstall",
+    "install-local": "bash scripts/reinstall-local.sh"
   },
   "devDependencies": {
     "concurrently": "^9.1.0",


### PR DESCRIPTION
## Summary

The merge in PR #34 (merge-upstream-auth-v2) overwrote `package.json` with the upstream version, losing local customizations that were added in PR #33.

## Restored Scripts

| Script | Command | Purpose |
|--------|---------|---------|
| `start` | `bun scripts/start-native.ts --tunnel` | Start with Cloudflare tunnel |
| `start:client` | `bun scripts/start-native.ts --client --tunnel` | Connect to existing opencode |
| `start:no-tunnel` | `bun scripts/start-native.ts` | Local only, no tunnel |
| `tunnel:start` | `bun scripts/tunnel.ts start` | Start persistent tunnel |
| `tunnel:stop` | `bun scripts/tunnel.ts stop` | Stop tunnel |
| `tunnel:status` | `bun scripts/tunnel.ts status` | Check tunnel status |
| `cleanup` | `bun scripts/cleanup.ts` | Kill managed ports |
| `prepublishOnly` | `pnpm run build` | Auto-build before npm publish |
| `install:opencode-attach` | `bun scripts/install-opencode-attach.ts` | Install attach script |
| `uninstall:opencode-attach` | `bun scripts/install-opencode-attach.ts uninstall` | Uninstall attach |
| `install-local` | `bash scripts/reinstall-local.sh` | Local dev install |

## Restored Metadata (for npm publishing)

- `bin` - CLI entry point (`opencode-manager` command)
- `files` - npm publish file list
- `description` - Package description
- `repository` - GitHub repo URL
- `keywords` - npm search keywords
- `author` - Package author
- `license` - MIT license

## Root Cause

The upstream merge brought in their `package.json` which didn't have these local customizations. Future merges should be more careful to preserve local script additions.