### PR TITLE
feat: add stop, restart CLI commands for service management

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import { createPushRoutes } from './routes/push'
 import { createTaskRoutes } from './routes/tasks'
 import { createTelegramRoutes } from './routes/telegram'
 import { createTunnelRoutes } from './routes/tunnel'
+import { createServicesRoutes } from './routes/services'
 import { terminalService } from './services/terminal'
 import { schedulerService } from './services/scheduler'
 import { telegramService } from './services/telegram'
@@ -407,6 +408,7 @@ app.route('/api/push', createPushRoutes(db))
 app.route('/api/tasks', createTaskRoutes(db))
 app.route('/api/telegram', createTelegramRoutes(db))
 app.route('/api/tunnel', createTunnelRoutes())
+app.route('/api/services', createServicesRoutes(db))
 
 app.all('/api/opencode/*', async (c) => {
   const request = c.req.raw

--- a/backend/src/routes/services.ts
+++ b/backend/src/routes/services.ts
@@ -1,0 +1,300 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { whisperServerManager } from '../services/whisper'
+import { coquiServerManager } from '../services/coqui'
+import { chatterboxServerManager } from '../services/chatterbox'
+import { opencodeServerManager } from '../services/opencode-single-server'
+import { SettingsService } from '../services/settings'
+import { logger } from '../utils/logger'
+import type { Database } from 'bun:sqlite'
+
+type ServiceName = 'stt' | 'tts' | 'opencode'
+
+const ServiceParamSchema = z.object({
+  service: z.enum(['stt', 'tts', 'opencode', 'all'])
+})
+
+interface ServiceStatus {
+  name: string
+  status: 'running' | 'stopped' | 'not_configured' | 'unknown'
+  error?: string
+  details?: Record<string, unknown>
+}
+
+async function getServiceStatus(service: ServiceName, db: Database): Promise<ServiceStatus> {
+  switch (service) {
+    case 'stt': {
+      const status = whisperServerManager.getStatus()
+      return {
+        name: 'stt',
+        status: status.running ? 'running' : 'stopped',
+        error: status.error || undefined,
+        details: {
+          port: status.port,
+          model: status.model
+        }
+      }
+    }
+    case 'tts': {
+      const settingsService = new SettingsService(db)
+      const settings = settingsService.getSettings('default')
+      const provider = settings.preferences.tts?.provider || 'external'
+      
+      if (provider === 'coqui') {
+        const coquiStatus = coquiServerManager.getStatus()
+        return {
+          name: 'tts',
+          status: coquiStatus.running ? 'running' : 'stopped',
+          error: coquiStatus.error || undefined,
+          details: {
+            provider: 'coqui',
+            port: coquiStatus.port,
+            model: coquiStatus.model,
+            device: coquiStatus.device
+          }
+        }
+      }
+      
+      if (provider === 'chatterbox') {
+        const chatterboxStatus = chatterboxServerManager.getStatus()
+        return {
+          name: 'tts',
+          status: chatterboxStatus.running ? 'running' : 'stopped',
+          error: chatterboxStatus.error || undefined,
+          details: {
+            provider: 'chatterbox',
+            port: chatterboxStatus.port,
+            device: chatterboxStatus.device
+          }
+        }
+      }
+      
+      return {
+        name: 'tts',
+        status: settings.preferences.tts?.enabled ? 'running' : 'not_configured',
+        details: { provider }
+      }
+    }
+    case 'opencode': {
+      const healthy = await opencodeServerManager.checkHealth()
+      return {
+        name: 'opencode',
+        status: healthy ? 'running' : 'stopped',
+        error: opencodeServerManager.getLastStartupError() || undefined,
+        details: {
+          port: opencodeServerManager.getPort(),
+          version: opencodeServerManager.getVersion()
+        }
+      }
+    }
+    default:
+      return { name: service, status: 'unknown' }
+  }
+}
+
+async function startService(service: ServiceName, db: Database): Promise<{ success: boolean; error?: string }> {
+  try {
+    switch (service) {
+      case 'stt':
+        await whisperServerManager.start()
+        return { success: true }
+      case 'tts': {
+        const settingsService = new SettingsService(db)
+        const settings = settingsService.getSettings('default')
+        const provider = settings.preferences.tts?.provider || 'external'
+        
+        if (provider === 'coqui') {
+          await coquiServerManager.start()
+          return { success: true }
+        }
+        
+        if (provider === 'chatterbox') {
+          await chatterboxServerManager.start()
+          return { success: true }
+        }
+        
+        return { success: false, error: `TTS provider '${provider}' does not require a local server` }
+      }
+      case 'opencode':
+        await opencodeServerManager.start()
+        return { success: true }
+      default:
+        return { success: false, error: `Unknown service: ${service}` }
+    }
+  } catch (error) {
+    logger.error(`Failed to start service ${service}:`, error)
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+async function stopService(service: ServiceName, db: Database): Promise<{ success: boolean; error?: string }> {
+  try {
+    switch (service) {
+      case 'stt':
+        await whisperServerManager.stop()
+        return { success: true }
+      case 'tts': {
+        const settingsService = new SettingsService(db)
+        const settings = settingsService.getSettings('default')
+        const provider = settings.preferences.tts?.provider || 'external'
+        
+        if (provider === 'coqui') {
+          await coquiServerManager.stop()
+          return { success: true }
+        }
+        
+        if (provider === 'chatterbox') {
+          await chatterboxServerManager.stop()
+          return { success: true }
+        }
+        
+        return { success: false, error: `TTS provider '${provider}' does not have a local server to stop` }
+      }
+      case 'opencode':
+        await opencodeServerManager.stop()
+        return { success: true }
+      default:
+        return { success: false, error: `Unknown service: ${service}` }
+    }
+  } catch (error) {
+    logger.error(`Failed to stop service ${service}:`, error)
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+async function restartService(service: ServiceName, db: Database): Promise<{ success: boolean; error?: string }> {
+  try {
+    switch (service) {
+      case 'stt':
+        await whisperServerManager.stop()
+        await new Promise(r => setTimeout(r, 1000))
+        await whisperServerManager.start()
+        return { success: true }
+      case 'tts': {
+        const settingsService = new SettingsService(db)
+        const settings = settingsService.getSettings('default')
+        const provider = settings.preferences.tts?.provider || 'external'
+        
+        if (provider === 'coqui') {
+          await coquiServerManager.stop()
+          await new Promise(r => setTimeout(r, 1000))
+          await coquiServerManager.start()
+          return { success: true }
+        }
+        
+        if (provider === 'chatterbox') {
+          await chatterboxServerManager.stop()
+          await new Promise(r => setTimeout(r, 1000))
+          await chatterboxServerManager.start()
+          return { success: true }
+        }
+        
+        return { success: false, error: `TTS provider '${provider}' does not have a local server to restart` }
+      }
+      case 'opencode':
+        await opencodeServerManager.restart()
+        return { success: true }
+      default:
+        return { success: false, error: `Unknown service: ${service}` }
+    }
+  } catch (error) {
+    logger.error(`Failed to restart service ${service}:`, error)
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+export function createServicesRoutes(db: Database) {
+  const app = new Hono()
+
+  app.get('/', async (c) => {
+    const services: ServiceName[] = ['stt', 'tts', 'opencode']
+    const statuses = await Promise.all(services.map(s => getServiceStatus(s, db)))
+    return c.json({ services: statuses })
+  })
+
+  app.get('/:service', async (c) => {
+    const service = c.req.param('service')
+    const validation = ServiceParamSchema.safeParse({ service })
+    
+    if (!validation.success) {
+      return c.json({ error: 'Invalid service name', valid: ['stt', 'tts', 'opencode', 'all'] }, 400)
+    }
+    
+    if (service === 'all') {
+      const services: ServiceName[] = ['stt', 'tts', 'opencode']
+      const statuses = await Promise.all(services.map(s => getServiceStatus(s, db)))
+      return c.json({ services: statuses })
+    }
+    
+    const status = await getServiceStatus(service as ServiceName, db)
+    return c.json(status)
+  })
+
+  app.post('/:service/start', async (c) => {
+    const service = c.req.param('service')
+    const validation = ServiceParamSchema.safeParse({ service })
+    
+    if (!validation.success) {
+      return c.json({ error: 'Invalid service name', valid: ['stt', 'tts', 'opencode', 'all'] }, 400)
+    }
+    
+    if (service === 'all') {
+      const services: ServiceName[] = ['stt', 'tts', 'opencode']
+      const results = await Promise.all(services.map(async s => ({
+        service: s,
+        ...await startService(s, db)
+      })))
+      const allSuccess = results.every(r => r.success)
+      return c.json({ success: allSuccess, results })
+    }
+    
+    const result = await startService(service as ServiceName, db)
+    return c.json(result, result.success ? 200 : 500)
+  })
+
+  app.post('/:service/stop', async (c) => {
+    const service = c.req.param('service')
+    const validation = ServiceParamSchema.safeParse({ service })
+    
+    if (!validation.success) {
+      return c.json({ error: 'Invalid service name', valid: ['stt', 'tts', 'opencode', 'all'] }, 400)
+    }
+    
+    if (service === 'all') {
+      const services: ServiceName[] = ['stt', 'tts', 'opencode']
+      const results = await Promise.all(services.map(async s => ({
+        service: s,
+        ...await stopService(s, db)
+      })))
+      const allSuccess = results.every(r => r.success)
+      return c.json({ success: allSuccess, results })
+    }
+    
+    const result = await stopService(service as ServiceName, db)
+    return c.json(result, result.success ? 200 : 500)
+  })
+
+  app.post('/:service/restart', async (c) => {
+    const service = c.req.param('service')
+    const validation = ServiceParamSchema.safeParse({ service })
+    
+    if (!validation.success) {
+      return c.json({ error: 'Invalid service name', valid: ['stt', 'tts', 'opencode', 'all'] }, 400)
+    }
+    
+    if (service === 'all') {
+      const services: ServiceName[] = ['stt', 'tts', 'opencode']
+      const results = await Promise.all(services.map(async s => ({
+        service: s,
+        ...await restartService(s, db)
+      })))
+      const allSuccess = results.every(r => r.success)
+      return c.json({ success: allSuccess, results })
+    }
+    
+    const result = await restartService(service as ServiceName, db)
+    return c.json(result, result.success ? 200 : 500)
+  })
+
+  return app
+}

--- a/backend/test/routes/services.test.ts
+++ b/backend/test/routes/services.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('bun:sqlite', () => ({
+  Database: vi.fn(),
+}))
+
+vi.mock('../../src/utils/logger', async () => {
+  return {
+    logger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../../src/services/settings', () => ({
+  SettingsService: vi.fn().mockImplementation(() => ({
+    getSettings: vi.fn().mockReturnValue({
+      preferences: {
+        tts: {
+          enabled: true,
+          provider: 'coqui',
+        }
+      }
+    })
+  }))
+}))
+
+vi.mock('../../src/services/whisper', () => ({
+  whisperServerManager: {
+    getStatus: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+}))
+
+vi.mock('../../src/services/coqui', () => ({
+  coquiServerManager: {
+    getStatus: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+}))
+
+vi.mock('../../src/services/chatterbox', () => ({
+  chatterboxServerManager: {
+    getStatus: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }
+}))
+
+vi.mock('../../src/services/opencode-single-server', () => ({
+  opencodeServerManager: {
+    checkHealth: vi.fn(),
+    getPort: vi.fn(),
+    getVersion: vi.fn(),
+    getLastStartupError: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+  }
+}))
+
+import { createServicesRoutes } from '../../src/routes/services'
+import { whisperServerManager } from '../../src/services/whisper'
+import { coquiServerManager } from '../../src/services/coqui'
+import { opencodeServerManager } from '../../src/services/opencode-single-server'
+
+describe('Services Routes', () => {
+  let mockDb: any
+  let servicesApp: ReturnType<typeof createServicesRoutes>
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb = {} as any;
+    
+    (whisperServerManager.getStatus as any).mockReturnValue({
+      running: true,
+      port: 5552,
+      model: 'base',
+      error: null
+    });
+    (whisperServerManager.start as any).mockResolvedValue(undefined);
+    (whisperServerManager.stop as any).mockResolvedValue(undefined);
+    
+    (coquiServerManager.getStatus as any).mockReturnValue({
+      running: true,
+      port: 5553,
+      model: 'jenny',
+      device: 'cpu',
+      error: null
+    });
+    (coquiServerManager.start as any).mockResolvedValue(undefined);
+    (coquiServerManager.stop as any).mockResolvedValue(undefined);
+    
+    (opencodeServerManager.checkHealth as any).mockResolvedValue(true);
+    (opencodeServerManager.getPort as any).mockReturnValue(5551);
+    (opencodeServerManager.getVersion as any).mockReturnValue('1.0.0');
+    (opencodeServerManager.getLastStartupError as any).mockReturnValue(null);
+    (opencodeServerManager.start as any).mockResolvedValue(undefined);
+    (opencodeServerManager.stop as any).mockResolvedValue(undefined);
+    (opencodeServerManager.restart as any).mockResolvedValue(undefined);
+    
+    servicesApp = createServicesRoutes(mockDb);
+  })
+
+  describe('GET /', () => {
+    it('should return status of all services', async () => {
+      const res = await servicesApp.request('/')
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.services).toHaveLength(3)
+      expect(data.services.map((s: any) => s.name)).toEqual(['stt', 'tts', 'opencode'])
+    })
+  })
+
+  describe('GET /:service', () => {
+    it('should return STT service status', async () => {
+      const res = await servicesApp.request('/stt')
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.name).toBe('stt')
+      expect(data.status).toBe('running')
+      expect(data.details.port).toBe(5552)
+    })
+
+    it('should return TTS service status', async () => {
+      const res = await servicesApp.request('/tts')
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.name).toBe('tts')
+      expect(data.status).toBe('running')
+      expect(data.details.provider).toBe('coqui')
+    })
+
+    it('should return OpenCode service status', async () => {
+      const res = await servicesApp.request('/opencode')
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.name).toBe('opencode')
+      expect(data.status).toBe('running')
+      expect(data.details.port).toBe(5551)
+    })
+
+    it('should return all services for /all', async () => {
+      const res = await servicesApp.request('/all')
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.services).toHaveLength(3)
+    })
+
+    it('should return error for invalid service', async () => {
+      const res = await servicesApp.request('/invalid')
+      const data = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(data.error).toBe('Invalid service name')
+    })
+  })
+
+  describe('POST /:service/stop', () => {
+    it('should stop STT service', async () => {
+      const res = await servicesApp.request('/stt/stop', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(whisperServerManager.stop).toHaveBeenCalled()
+    })
+
+    it('should stop TTS service', async () => {
+      const res = await servicesApp.request('/tts/stop', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(coquiServerManager.stop).toHaveBeenCalled()
+    })
+
+    it('should stop OpenCode service', async () => {
+      const res = await servicesApp.request('/opencode/stop', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(opencodeServerManager.stop).toHaveBeenCalled()
+    })
+
+    it('should stop all services', async () => {
+      const res = await servicesApp.request('/all/stop', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.results).toHaveLength(3)
+    })
+  })
+
+  describe('POST /:service/start', () => {
+    it('should start STT service', async () => {
+      const res = await servicesApp.request('/stt/start', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(whisperServerManager.start).toHaveBeenCalled()
+    })
+
+    it('should start TTS service', async () => {
+      const res = await servicesApp.request('/tts/start', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(coquiServerManager.start).toHaveBeenCalled()
+    })
+
+    it('should start OpenCode service', async () => {
+      const res = await servicesApp.request('/opencode/start', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(opencodeServerManager.start).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /:service/restart', () => {
+    it('should restart STT service', async () => {
+      const res = await servicesApp.request('/stt/restart', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(whisperServerManager.stop).toHaveBeenCalled()
+      expect(whisperServerManager.start).toHaveBeenCalled()
+    })
+
+    it('should restart OpenCode service', async () => {
+      const res = await servicesApp.request('/opencode/restart', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(opencodeServerManager.restart).toHaveBeenCalled()
+    })
+
+    it('should restart all services', async () => {
+      const res = await servicesApp.request('/all/restart', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(data.success).toBe(true)
+      expect(data.results).toHaveLength(3)
+    })
+  })
+
+  describe('Error handling', () => {
+    it('should handle stop errors gracefully', async () => {
+      (whisperServerManager.stop as any).mockRejectedValueOnce(new Error('Stop failed'));
+      
+      const res = await servicesApp.request('/stt/stop', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Stop failed')
+    })
+
+    it('should handle start errors gracefully', async () => {
+      (opencodeServerManager.start as any).mockRejectedValueOnce(new Error('Start failed'));
+      
+      const res = await servicesApp.request('/opencode/start', { method: 'POST' })
+      const data = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(data.success).toBe(false)
+      expect(data.error).toBe('Start failed')
+    })
+  })
+})

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -138,6 +138,8 @@ Usage: opencode-manager <command> [options]
 
 Commands:
   start              Start the OpenCode Manager server
+  stop [service]     Stop a service (stt, tts, opencode, all)
+  restart [service]  Restart a service (stt, tts, opencode, all)
   status             Check status of locally running service
   install-service    Install as a user service (macOS/Linux)
   uninstall-service  Remove the user service
@@ -149,6 +151,10 @@ Start Options:
   --tunnel, -t       Start a Cloudflare tunnel for public access
   --port, -p <port>  Backend API port (default: 5001)
   --no-auth          Disable basic authentication
+
+Stop/Restart Options:
+  --port, -p <port>  Backend API port (default: 5001)
+  service            Service to stop/restart: stt, tts, opencode, all (default: all)
 
 Status Options:
   --port, -p <port>  Backend API port to check (default: 5001)
@@ -163,6 +169,8 @@ one will be started automatically.
 Examples:
   opencode-manager start
   opencode-manager start --tunnel
+  opencode-manager stop stt
+  opencode-manager restart tts
   opencode-manager status
   opencode-manager install-service
   opencode-manager install-service --no-tunnel
@@ -1003,6 +1011,152 @@ async function commandHealth(args: string[]): Promise<void> {
   process.exit(coreHealthy ? 0 : 1)
 }
 
+type ValidService = 'stt' | 'tts' | 'opencode' | 'all'
+
+function isValidService(service: string): service is ValidService {
+  return ['stt', 'tts', 'opencode', 'all'].includes(service)
+}
+
+interface ServiceActionResult {
+  success: boolean
+  error?: string
+  results?: Array<{ service: string; success: boolean; error?: string }>
+}
+
+async function callServiceAPI(
+  port: number, 
+  service: ValidService, 
+  action: 'start' | 'stop' | 'restart',
+  auth: AuthConfig | null
+): Promise<ServiceActionResult> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  }
+  if (auth?.username && auth?.password) {
+    headers['Authorization'] = `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`
+  }
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/services/${service}/${action}`, {
+      method: 'POST',
+      headers,
+      signal: AbortSignal.timeout(120000)
+    })
+
+    if (response.status === 401) {
+      return { success: false, error: 'Authentication required. Check credentials in ~/.local/run/opencode-manager/auth.json' }
+    }
+
+    const data = await response.json() as ServiceActionResult
+    return data
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { success: false, error: 'Operation timed out after 2 minutes' }
+    }
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' }
+  }
+}
+
+async function commandStop(args: string[]): Promise<void> {
+  const portIdx = args.findIndex(a => a === '--port' || a === '-p')
+  const port = portIdx >= 0 ? parseInt(args[portIdx + 1]) || DEFAULT_PORT : DEFAULT_PORT
+  
+  const serviceArgs = portIdx >= 0 
+    ? args.filter((_, i) => i !== portIdx && i !== portIdx + 1)
+    : args
+  const service = serviceArgs[0] || 'all'
+  
+  if (!isValidService(service)) {
+    console.error(`Invalid service: ${service}`)
+    console.error('Valid services: stt, tts, opencode, all')
+    process.exit(1)
+  }
+
+  let auth: AuthConfig | null = null
+  if (fs.existsSync(AUTH_FILE)) {
+    try {
+      auth = JSON.parse(fs.readFileSync(AUTH_FILE, 'utf8')) as AuthConfig
+    } catch {}
+  }
+
+  console.log(`\nStopping ${service === 'all' ? 'all services' : service}...`)
+
+  const result = await callServiceAPI(port, service, 'stop', auth)
+
+  if (result.success) {
+    if (result.results) {
+      console.log('\nResults:')
+      for (const r of result.results) {
+        const status = r.success ? '✓' : '✗'
+        console.log(`  ${status} ${r.service}: ${r.success ? 'stopped' : r.error || 'failed'}`)
+      }
+    } else {
+      console.log(`✓ ${service} stopped successfully`)
+    }
+    process.exit(0)
+  } else {
+    console.error(`\n✗ Failed to stop ${service}: ${result.error}`)
+    if (result.results) {
+      console.log('\nPartial results:')
+      for (const r of result.results) {
+        const status = r.success ? '✓' : '✗'
+        console.log(`  ${status} ${r.service}: ${r.success ? 'stopped' : r.error || 'failed'}`)
+      }
+    }
+    process.exit(1)
+  }
+}
+
+async function commandRestart(args: string[]): Promise<void> {
+  const portIdx = args.findIndex(a => a === '--port' || a === '-p')
+  const port = portIdx >= 0 ? parseInt(args[portIdx + 1]) || DEFAULT_PORT : DEFAULT_PORT
+  
+  const serviceArgs = portIdx >= 0 
+    ? args.filter((_, i) => i !== portIdx && i !== portIdx + 1)
+    : args
+  const service = serviceArgs[0] || 'all'
+  
+  if (!isValidService(service)) {
+    console.error(`Invalid service: ${service}`)
+    console.error('Valid services: stt, tts, opencode, all')
+    process.exit(1)
+  }
+
+  let auth: AuthConfig | null = null
+  if (fs.existsSync(AUTH_FILE)) {
+    try {
+      auth = JSON.parse(fs.readFileSync(AUTH_FILE, 'utf8')) as AuthConfig
+    } catch {}
+  }
+
+  console.log(`\nRestarting ${service === 'all' ? 'all services' : service}...`)
+
+  const result = await callServiceAPI(port, service, 'restart', auth)
+
+  if (result.success) {
+    if (result.results) {
+      console.log('\nResults:')
+      for (const r of result.results) {
+        const status = r.success ? '✓' : '✗'
+        console.log(`  ${status} ${r.service}: ${r.success ? 'restarted' : r.error || 'failed'}`)
+      }
+    } else {
+      console.log(`✓ ${service} restarted successfully`)
+    }
+    process.exit(0)
+  } else {
+    console.error(`\n✗ Failed to restart ${service}: ${result.error}`)
+    if (result.results) {
+      console.log('\nPartial results:')
+      for (const r of result.results) {
+        const status = r.success ? '✓' : '✗'
+        console.log(`  ${status} ${r.service}: ${r.success ? 'restarted' : r.error || 'failed'}`)
+      }
+    }
+    process.exit(1)
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2)
   const command = args[0] || 'help'
@@ -1011,6 +1165,12 @@ async function main(): Promise<void> {
   switch (command) {
     case 'start':
       await commandStart(commandArgs)
+      break
+    case 'stop':
+      await commandStop(commandArgs)
+      break
+    case 'restart':
+      await commandRestart(commandArgs)
       break
     case 'status':
       await commandHealth(commandArgs)


### PR DESCRIPTION
## Summary

- Add `/api/services` backend routes for managing individual services
- Add `stop` CLI command to stop STT, TTS, OpenCode, or all services
- Add `restart` CLI command to restart services
- Enable recovery from degraded states without full application restart

## CLI Usage

```bash
# Stop a specific service
opencode-manager stop stt
opencode-manager stop tts
opencode-manager stop opencode
opencode-manager stop all

# Restart a specific service
opencode-manager restart stt
opencode-manager restart tts
opencode-manager restart opencode
opencode-manager restart all

# With custom port
opencode-manager stop stt --port 5002
opencode-manager restart all -p 5002
```

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/services` | List all services and their status |
| GET | `/api/services/:service` | Get status of a specific service |
| POST | `/api/services/:service/start` | Start a service |
| POST | `/api/services/:service/stop` | Stop a service |
| POST | `/api/services/:service/restart` | Restart a service |

## Testing

- Added unit tests for all service routes
- All 86 backend tests pass