### PR TITLE
fix: show voice buttons on mobile and improve TTS model discovery

### DIFF
--- a/backend/src/services/coqui.ts
+++ b/backend/src/services/coqui.ts
@@ -14,6 +14,49 @@ const COQUI_DEVICE = process.env.COQUI_DEVICE || 'auto'
 const COQUI_MODEL = process.env.COQUI_MODEL || 'tts_models/en/jenny/jenny'
 const DEFAULT_VENV_DIR = path.join(os.homedir(), '.opencode-manager', 'coqui-venv')
 
+const RECOMMENDED_MODELS = [
+  {
+    id: "tts_models/en/vctk/vits",
+    name: "VCTK VITS",
+    description: "VCTK VITS (109 speakers, recommended)",
+    quality: "high",
+    speed: "fast",
+    multi_speaker: true
+  },
+  {
+    id: "tts_models/en/ljspeech/vits",
+    name: "LJSpeech VITS",
+    description: "LJSpeech single speaker",
+    quality: "high",
+    speed: "fast",
+    multi_speaker: false
+  },
+  {
+    id: "tts_models/en/jenny/jenny",
+    name: "Jenny",
+    description: "Jenny voice",
+    quality: "high",
+    speed: "medium",
+    multi_speaker: false
+  },
+  {
+    id: "tts_models/multilingual/multi-dataset/xtts_v2",
+    name: "XTTS v2",
+    description: "XTTS v2 with voice cloning",
+    quality: "very_high",
+    speed: "slow",
+    multi_speaker: true
+  },
+  {
+    id: "tts_models/multilingual/multi-dataset/bark",
+    name: "Bark",
+    description: "Multilingual neural TTS",
+    quality: "high",
+    speed: "slow",
+    multi_speaker: false
+  }
+]
+
 interface CoquiServerStatus {
   running: boolean
   port: number
@@ -410,13 +453,7 @@ class CoquiServerManager {
   }> {
     if (!this.status.running) {
       return {
-        models: [{
-          id: 'tts_models/en/jenny/jenny',
-          name: 'Jenny',
-          description: 'High-quality English female voice (recommended)',
-          quality: 'high',
-          speed: 'fast'
-        }],
+        models: RECOMMENDED_MODELS,
         currentModel: COQUI_MODEL
       }
     }
@@ -440,13 +477,7 @@ class CoquiServerManager {
     }
 
     return {
-      models: [{
-        id: 'tts_models/en/jenny/jenny',
-        name: 'Jenny',
-        description: 'High-quality English female voice (recommended)',
-        quality: 'high',
-        speed: 'fast'
-      }],
+      models: RECOMMENDED_MODELS,
       currentModel: COQUI_MODEL
     }
   }

--- a/frontend/src/components/message/PromptInput.tsx
+++ b/frontend/src/components/message/PromptInput.tsx
@@ -723,7 +723,6 @@ return (
               }
             }}
             disabled={disabled}
-            className="hidden md:block"
           />
           <ContinuousVoiceButton
             onTranscriptUpdate={(text) => {
@@ -750,7 +749,6 @@ return (
               }
             }}
             disabled={disabled}
-            className="hidden md:block"
           />
             <button
                data-submit-prompt


### PR DESCRIPTION
## Summary
- Show voice input buttons (microphone icons) on mobile devices
- Improve TTS model discovery fallback with full list of recommended models

## Changes
1. **Mobile Voice Buttons**: Removed `hidden md:block` class from `VoiceButton` and `ContinuousVoiceButton` components in `PromptInput.tsx`. Voice input is now accessible on all screen sizes.

2. **TTS Model Discovery**: Added `RECOMMENDED_MODELS` constant to `backend/src/services/coqui.ts` with full list of TTS models (VCTK, LJSpeech, Jenny, XTTS v2, Bark). This provides better fallback when the Coqui server is still initializing.

## Testing
- [x] Backend tests pass (180/180)
- [x] Build succeeds