### PR TITLE
fix: enable mobile scrolling on repos/home page

### DIFF
--- a/frontend/src/pages/Repos.tsx
+++ b/frontend/src/pages/Repos.tsx
@@ -86,7 +86,7 @@ export function Repos() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-background">
+    <div className="h-dvh max-h-dvh overflow-hidden bg-gradient-to-br from-background via-background to-background flex flex-col">
       <Header
         title="OpenCode"
         action={
@@ -126,18 +126,20 @@ export function Repos() {
           </div>
         }
       />
-      <div className="container mx-auto sm:p-2 p-4">
-        <div className="mb-6">
-          <div className="flex items-center gap-2 mb-3">
-            <Clock className="w-4 h-4 text-muted-foreground" />
-            <h2 className="text-sm font-medium text-muted-foreground">Recent Sessions (Last 8 hours)</h2>
+      <div className="flex-1 overflow-y-auto min-h-0">
+        <div className="container mx-auto sm:p-2 p-4">
+          <div className="mb-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Clock className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-sm font-medium text-muted-foreground">Recent Sessions (Last 8 hours)</h2>
+            </div>
+            <RecentSessions maxItems={5} />
           </div>
-          <RecentSessions maxItems={5} />
+          <div className="mb-3">
+            <h2 className="text-sm font-medium text-muted-foreground">Repositories</h2>
+          </div>
+          <RepoList />
         </div>
-        <div className="mb-3">
-          <h2 className="text-sm font-medium text-muted-foreground">Repositories</h2>
-        </div>
-        <RepoList />
       </div>
       <AddRepoDialog open={addRepoOpen} onOpenChange={setAddRepoOpen} />
       <FileBrowserSheet


### PR DESCRIPTION
## Summary
- Fix scrolling on mobile devices for the repos/home page
- The page used `min-h-screen` without a scroll container, which prevented scrolling due to `body { overflow: hidden }` in index.css
- Changed to `h-dvh max-h-dvh overflow-hidden flex flex-col` pattern with `flex-1 overflow-y-auto` scrollable content area
- This matches the working pattern already used in `RepoDetail.tsx`

## Testing Done
- [x] Code review of changes
- [x] Pattern matches working `RepoDetail.tsx` implementation

## Root Cause
`frontend/src/index.css` has `body { overflow: hidden; position: fixed; }` to prevent iOS bounce effects. This requires all pages to explicitly handle scrolling with `overflow-y-auto` containers. The Repos page was missing this.