### PR TITLE
fix: include ~/.opencode/bin in launchd plist PATH and add throttle interval (#51)

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -557,6 +557,18 @@ function getFullPath(): string {
     '/opt/homebrew/sbin',
   ]
   
+  const wellKnownDirs = [
+    path.join(os.homedir(), '.opencode', 'bin'),
+    path.join(os.homedir(), '.bun', 'bin'),
+    path.join(os.homedir(), '.local', 'bin'),
+    path.join(os.homedir(), '.cargo', 'bin'),
+  ]
+  for (const dir of wellKnownDirs) {
+    if (fs.existsSync(dir)) {
+      basePaths.push(dir)
+    }
+  }
+  
   try {
     const bunPath = execSync('which bun', { encoding: 'utf8' }).trim()
     basePaths.push(path.dirname(bunPath))
@@ -587,11 +599,6 @@ function getFullPath(): string {
     } catch {}
   }
   
-  const userLocalBin = path.join(os.homedir(), '.local', 'bin')
-  if (fs.existsSync(userLocalBin)) {
-    basePaths.push(userLocalBin)
-  }
-  
   const uniquePaths = [...new Set(basePaths)]
   return uniquePaths.join(':')
 }
@@ -609,6 +616,23 @@ function commandInstallService(args: string[]): void {
   const cliPath = path.join(packageDir, 'bin', 'cli.ts')
   const bunPath = execSync('which bun', { encoding: 'utf8' }).trim()
   const fullPath = getFullPath()
+
+  let opencodeBinFound = false
+  try {
+    execSync('which opencode', { encoding: 'utf8' }).trim()
+    opencodeBinFound = true
+  } catch {}
+  if (!opencodeBinFound) {
+    const fallback = path.join(os.homedir(), '.opencode', 'bin', 'opencode')
+    opencodeBinFound = fs.existsSync(fallback)
+  }
+  if (!opencodeBinFound) {
+    console.warn('⚠️  Warning: "opencode" binary not found in PATH or ~/.opencode/bin')
+    console.warn('   The service will fail to start without it.')
+    console.warn('   Install opencode: curl -fsSL https://opencode.ai/install | bash\n')
+  }
+
+  console.log(`   PATH: ${fullPath}\n`)
 
   const startArgs = ['start', '--client']
   if (hasTunnel) startArgs.push('--tunnel')
@@ -637,6 +661,8 @@ ${startArgs.map(a => `    <string>${a}</string>`).join('\n')}
   <true/>
   <key>KeepAlive</key>
   <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
   <key>WorkingDirectory</key>
   <string>${packageDir}</string>
   <key>StandardOutPath</key>


### PR DESCRIPTION
## Summary
- Add well-known user binary directories (`~/.opencode/bin`, `~/.bun/bin`, `~/.local/bin`, `~/.cargo/bin`) as hardcoded fallbacks in `getFullPath()` so the launchd plist PATH always includes them when they exist on disk
- Add `ThrottleInterval` of 30s to the macOS plist to prevent crash loop flooding when the service fails
- Validate that the `opencode` binary exists at `install-service` time and warn the user if not found

## Root Cause
After macOS reboot, the launchd service failed with `Executable not found in $PATH: "opencode"`. The `opencode` binary lives at `~/.opencode/bin/opencode`, but `getFullPath()` only discovered it dynamically via `which opencode` at install time. Without `~/.opencode/bin` as a hardcoded well-known path, the plist PATH was missing it, causing an infinite crash loop.

## Testing Done
- [x] Verified `~/.opencode/bin` appears in generated plist PATH
- [x] Installed service with `bun bin/cli.ts install-service --no-tunnel`
- [x] Confirmed `launchctl list | grep opencode` shows PID (running)
- [x] Confirmed `curl http://localhost:5001/api/health` returns `{"status":"healthy"}`

## Issue
Closes #51