### PR TITLE
fix: change dev port to 5003 to avoid conflict with launchd service (#60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,10 @@
 # ============================================
 # Backend Server Configuration
 # ============================================
-PORT=5001
+# NOTE: The launchd/systemd service uses port 5001 by default.
+# Use port 5003 (the built-in default) for local development
+# to avoid conflicts with the production service.
+PORT=5003
 HOST=0.0.0.0
 CORS_ORIGIN=http://localhost:5173
 NODE_ENV=development


### PR DESCRIPTION
## Summary

- Change `.env.example` default PORT from 5001 to 5003 to prevent dev mode from conflicting with the launchd/systemd production service which uses port 5001

## Root Cause

The tunnel was showing as "connected" but was actually dead (`ha_connections: 0`, cloudflared in `"Unauthorized: Tunnel not found"` retry loop). This happened because:

1. The launchd plist was installed without `--tunnel` (using `install-service --no-tunnel`)
2. A manual `opencode-manager start --tunnel` was run, competing with the service for port 5001
3. `.env.example` defaulted to PORT=5001, same as the service, making this conflict easy to trigger during development

## Fix

- Updated `.env.example` to use PORT=5003 (the built-in default from `shared/src/config/defaults.ts`)
- Added comment explaining port 5001 is reserved for the launchd/systemd service

## Operational Fix (already applied)

- Killed conflicting manual process
- Reinstalled launchd service with `--tunnel` flag (the default)
- Verified tunnel establishes with `ha_connections > 0`

Closes #60